### PR TITLE
Fix context processor path

### DIFF
--- a/notifications/context_processors/__init__.py
+++ b/notifications/context_processors/__init__.py
@@ -1,0 +1,1 @@
+from .unread_notifications import unread_notifications

--- a/notifications/context_processors/unread_notifications.py
+++ b/notifications/context_processors/unread_notifications.py
@@ -1,4 +1,4 @@
-from .models import Notification
+from ..models import Notification
 
 def unread_notifications(request):
     if not request.user.is_authenticated:

--- a/notifications/tests.py
+++ b/notifications/tests.py
@@ -1,3 +1,7 @@
 from django.test import TestCase
+from django.utils.module_loading import import_string
 
-# Create your tests here.
+class ContextProcessorsTests(TestCase):
+    def test_unread_notifications_import(self):
+        func = import_string('notifications.context_processors.unread_notifications')
+        self.assertTrue(callable(func))


### PR DESCRIPTION
## 변경 사항
- 알림 컨텍스트 프로세서를 패키지에서 바로 가져올 수 있도록 `__init__.py` 추가
- 상대 경로 오류 수정
- 임포트 가능 여부를 확인하는 테스트 작성

## 테스트 결과
- `python manage.py test` 실행 시 1개의 테스트가 통과함

------
https://chatgpt.com/codex/tasks/task_e_6845440b74848330b2582eda6af58fbd