### PR TITLE
UI 개선 및 프로필 링크 버그 수정

### DIFF
--- a/account/templates/account/login.html
+++ b/account/templates/account/login.html
@@ -1,7 +1,17 @@
-<!-- account/templates/account/login.html -->
-<h2>로그인</h2>
-<form method="post">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button type="submit">로그인</button>
-</form>
+{% load static %}
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>로그인</title>
+  <link rel="stylesheet" href="{% static 'main/global.css' %}">
+</head>
+<body>
+  <h2>로그인</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">로그인</button>
+  </form>
+</body>
+</html>

--- a/account/templates/account/signup.html
+++ b/account/templates/account/signup.html
@@ -1,5 +1,17 @@
-<h2>회원가입</h2>
-<form method="post">
-  {% csrf_token %} {{ form.as_p }}
-  <button type="submit">가입하기</button>
-</form>
+{% load static %}
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>회원가입</title>
+  <link rel="stylesheet" href="{% static 'main/global.css' %}">
+</head>
+<body>
+  <h2>회원가입</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">가입하기</button>
+  </form>
+</body>
+</html>

--- a/chat/templates/chat/list.html
+++ b/chat/templates/chat/list.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>채팅 목록</title>
     <link rel="stylesheet" href="{% static 'main/main.css' %}">
+    <link rel="stylesheet" href="{% static 'main/global.css' %}">
     <link rel="stylesheet" href="{% static 'chat/chat.css' %}">
 </head>
 <body>

--- a/chat/templates/chat/room.html
+++ b/chat/templates/chat/room.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <title>{{ other_user.nickname }}님과의 채팅</title>
     <link rel="stylesheet" href="{% static 'main/main.css' %}">
+    <link rel="stylesheet" href="{% static 'main/global.css' %}">
     <link rel="stylesheet" href="{% static 'chat/chat.css' %}">
 </head>
 <body>

--- a/main/static/main/global.css
+++ b/main/static/main/global.css
@@ -1,0 +1,26 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap');
+
+body, input, textarea, button, select {
+  font-family: 'Noto Sans KR', sans-serif;
+}
+
+input[type="text"], input[type="email"], input[type="password"], input[type="number"], textarea, select {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+button {
+  display: inline-block;
+  padding: 8px 16px;
+  background-color: #4caf50;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #45a049;
+}

--- a/main/static/main/main.css
+++ b/main/static/main/main.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: "Arial", sans-serif;
+  font-family: "Noto Sans KR", sans-serif;
   background-color: #f8f8f8;
 }
 header {
@@ -124,7 +124,7 @@ section {
   border-radius: 24px;
 
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  font-family: Arial, sans-serif;
+  font-family: "Noto Sans KR", sans-serif;
   display: flex;
   flex-direction: column;
 }

--- a/main/templates/main/header.html
+++ b/main/templates/main/header.html
@@ -4,6 +4,7 @@
   <head>
     <meta name="csrf-token" content="{{ csrf_token }}" />
     <meta name="logout-url" content="{% url 'account:logout' %}" />
+    <link rel="stylesheet" href="{% static 'main/global.css' %}">
     <style>
       header {
         display: flex;

--- a/main/templates/main/main.html
+++ b/main/templates/main/main.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GiveTime - 재능 기부 플랫폼</title>
     <link rel="stylesheet" href="{% static 'main/main.css' %}" />
+    <link rel="stylesheet" href="{% static 'main/global.css' %}" />
     <script src="{% static 'main/sakura.js' %}"></script>
   </head>
   <body>

--- a/mypage/templates/mypage/edit_profile.html
+++ b/mypage/templates/mypage/edit_profile.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>프로필 수정 | Give Time</title>
     <link rel="stylesheet" href="{% static 'mypage/mypage.css' %}">
+    <link rel="stylesheet" href="{% static 'main/global.css' %}">
 </head>
 <body>
 

--- a/mypage/templates/mypage/mypage.html
+++ b/mypage/templates/mypage/mypage.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <title>마이페이지 | Give Time</title>
     <link rel="stylesheet" href="{% static 'mypage/mypage.css' %}" />
+    <link rel="stylesheet" href="{% static 'main/global.css' %}" />
   </head>
   <body data-rank-level="{{ rank_level }}">
     <div id="petal-container"></div>

--- a/notifications/templates/notifications/list.html
+++ b/notifications/templates/notifications/list.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <title>알림</title>
   <link rel="stylesheet" href="{% static 'posts/board.css' %}">
+  <link rel="stylesheet" href="{% static 'main/global.css' %}">
 </head>
 <body>
   <div id="header">{% include 'main/header.html' %}</div>

--- a/posts/static/posts/board.css
+++ b/posts/static/posts/board.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: "Arial", sans-serif;
+  font-family: "Noto Sans KR", sans-serif;
   background-color: #f5f7fa; /* 부드러운 배경색 */
 }
 

--- a/posts/static/posts/form.css
+++ b/posts/static/posts/form.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Arial", sans-serif;
+  font-family: "Noto Sans KR", sans-serif;
   background-color: #f9f9f9;
   margin: 0;
   padding: 0;

--- a/posts/templates/posts/complete_modal.html
+++ b/posts/templates/posts/complete_modal.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <title>참여 완료</title>
   <link rel="stylesheet" href="{% static 'posts/detail.css' %}">
+  <link rel="stylesheet" href="{% static 'main/global.css' %}">
 </head>
 <body>
   <div class="content-wrapper">

--- a/posts/templates/posts/post_detail.html
+++ b/posts/templates/posts/post_detail.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <title>{{ post.title }}</title>
   <link rel="stylesheet" href="{% static 'posts/detail.css' %}" />
+  <link rel="stylesheet" href="{% static 'main/global.css' %}" />
 </head>
 <body>
   <!-- 상단 고정 네비게이션 -->
@@ -19,15 +20,15 @@
     <!-- 작성자 정보 -->
     <div class="author-info">
       {% if post.author.profile_image %}
-        <a href="{% url 'mypage:view_profile' post.author.id %}">
+        <a href="{% url 'mypage:view_profile' post.author.nickname %}">
           <img src="{{ post.author.profile_image.url }}" alt="작성자 프로필" class="profile-img-small" />
         </a>
       {% else %}
-        <a href="{% url 'mypage:view_profile' post.author.id %}">
+        <a href="{% url 'mypage:view_profile' post.author.nickname %}">
           <img src="{% static 'images/default_profile.png' %}" alt="기본 프로필" class="profile-img-small" />
         </a>
       {% endif %}
-      <a href="{% url 'mypage:view_profile' post.author.id %}">
+      <a href="{% url 'mypage:view_profile' post.author.nickname %}">
         <strong>{{ post.author.nickname }}</strong>
       </a>
       <span class="date">{{ post.created_at|date:"Y-m-d H:i" }}</span>
@@ -104,15 +105,15 @@
         <li>
           <div class="author-info">
             {% if comment.author.profile_image %}
-              <a href="{% url 'mypage:view_profile' comment.author.id %}">
+              <a href="{% url 'mypage:view_profile' comment.author.nickname %}">
                 <img src="{{ comment.author.profile_image.url }}" alt="작성자 프로필" class="profile-img-small" />
               </a>
             {% else %}
-              <a href="{% url 'mypage:view_profile' comment.author.id %}">
+              <a href="{% url 'mypage:view_profile' comment.author.nickname %}">
                 <img src="{% static 'images/default_profile.png' %}" alt="기본 프로필" class="profile-img-small" />
               </a>
             {% endif %}
-            <a href="{% url 'mypage:view_profile' comment.author.id %}">
+            <a href="{% url 'mypage:view_profile' comment.author.nickname %}">
               <strong>{{ comment.author.nickname }}</strong>
             </a>
             <span class="date">{{ comment.created_at|date:"Y-m-d H:i" }}</span>

--- a/posts/templates/posts/post_form.html
+++ b/posts/templates/posts/post_form.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <title>{{ post_type|title }} 게시글 작성</title>
     <link rel="stylesheet" href="{% static 'posts/form.css' %}" />
+    <link rel="stylesheet" href="{% static 'main/global.css' %}" />
   </head>
   <body>
     <div id="header">{% include 'main/header.html' %}</div>

--- a/posts/templates/posts/post_list.html
+++ b/posts/templates/posts/post_list.html
@@ -13,6 +13,7 @@
   </title>
 
   <link rel="stylesheet" href="{% static 'posts/board.css' %}" />
+  <link rel="stylesheet" href="{% static 'main/global.css' %}" />
   <style>
     /* a 태그 기본 파란색과 밑줄 제거 */
     a {
@@ -51,7 +52,7 @@
         <div class="card-meta">
           <div class="author-info">
             {% if post.author.profile_image %}
-              <a href="{% url 'mypage:view_profile' post.author.id %}">
+              <a href="{% url 'mypage:view_profile' post.author.nickname %}">
                 <img
                   src="{{ post.author.profile_image.url }}"
                   alt="작성자 프로필"
@@ -59,7 +60,7 @@
                 />
               </a>
             {% else %}
-              <a href="{% url 'mypage:view_profile' post.author.id %}">
+              <a href="{% url 'mypage:view_profile' post.author.nickname %}">
                 <img
                   src="{% static 'images/default_profile.png' %}"
                   alt="기본 프로필"
@@ -67,7 +68,7 @@
                 />
               </a>
             {% endif %}
-            <a href="{% url 'mypage:view_profile' post.author.id %}">
+            <a href="{% url 'mypage:view_profile' post.author.nickname %}">
               <span class="author">{{ post.author.nickname }}</span>
             </a>
           </div>
@@ -117,7 +118,7 @@
         <div class="sidebar-card-meta">
           <div class="author-info">
             {% if post.author.profile_image %}
-              <a href="{% url 'mypage:view_profile' post.author.id %}">
+              <a href="{% url 'mypage:view_profile' post.author.nickname %}">
                 <img
                   src="{{ post.author.profile_image.url }}"
                   alt="작성자 프로필"
@@ -125,7 +126,7 @@
                 />
               </a>
             {% else %}
-              <a href="{% url 'mypage:view_profile' post.author.id %}">
+              <a href="{% url 'mypage:view_profile' post.author.nickname %}">
                 <img
                   src="{% static 'images/default_profile.png' %}"
                   alt="기본 프로필"
@@ -133,7 +134,7 @@
                 />
               </a>
             {% endif %}
-            <a href="{% url 'mypage:view_profile' post.author.id %}">
+            <a href="{% url 'mypage:view_profile' post.author.nickname %}">
               <span class="author">{{ post.author.nickname }}</span>
             </a>
           </div>


### PR DESCRIPTION
## 변경 내용
- 사이트 전역에서 사용할 공통 CSS(`global.css`) 추가
- 글꼴을 `Noto Sans KR`로 통일하고 입력창/버튼 스타일을 일괄 적용
- 모든 템플릿에서 `global.css`를 로드하도록 수정
- 게시글 목록과 상세 페이지에서 프로필 사진 클릭 시 닉네임 기반 마이페이지로 이동하도록 수정

## 테스트
- `python manage.py test` 실행 시 Django 모듈 부재로 실패


------
https://chatgpt.com/codex/tasks/task_e_68454857f1188330ad1009656197cb30