### PR TITLE
Show rank badge beside post authors

### DIFF
--- a/main/static/main/global.css
+++ b/main/static/main/global.css
@@ -10,3 +10,25 @@ input[type="text"], input[type="email"], input[type="password"], input[type="num
   border-radius: 4px;
   box-sizing: border-box;
 }
+
+/* 사용자 등급 뱃지 공통 스타일 */
+.rank-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  margin-left: 6px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fff;
+}
+
+.rank-1 {
+  background-color: #95a5a6;
+}
+
+.rank-2 {
+  background-color: #3498db;
+}
+
+.rank-3 {
+  background-color: #e67e22;
+}

--- a/posts/templates/posts/post_detail.html
+++ b/posts/templates/posts/post_detail.html
@@ -30,6 +30,7 @@
       {% endif %}
       <a href="{% url 'mypage:view_profile' post.author.nickname %}">
         <strong>{{ post.author.nickname }}</strong>
+        <span class="rank-badge rank-{{ post.author.rank_level }}">{{ post.author.rank }}</span>
       </a>
       <span class="date">{{ post.created_at|date:"Y-m-d H:i" }}</span>
     </div>
@@ -115,6 +116,7 @@
             {% endif %}
             <a href="{% url 'mypage:view_profile' comment.author.nickname %}">
               <strong>{{ comment.author.nickname }}</strong>
+              <span class="rank-badge rank-{{ comment.author.rank_level }}">{{ comment.author.rank }}</span>
             </a>
             <span class="date">{{ comment.created_at|date:"Y-m-d H:i" }}</span>
           </div>

--- a/posts/templates/posts/post_list.html
+++ b/posts/templates/posts/post_list.html
@@ -70,6 +70,7 @@
             {% endif %}
             <a href="{% url 'mypage:view_profile' post.author.nickname %}">
               <span class="author">{{ post.author.nickname }}</span>
+              <span class="rank-badge rank-{{ post.author.rank_level }}">{{ post.author.rank }}</span>
             </a>
           </div>
           <span class="date">{{ post.created_at|date:"Y-m-d" }}</span>
@@ -137,6 +138,7 @@
             {% endif %}
             <a href="{% url 'mypage:view_profile' post.author.nickname %}">
               <span class="author">{{ post.author.nickname }}</span>
+              <span class="rank-badge rank-{{ post.author.rank_level }}">{{ post.author.rank }}</span>
             </a>
           </div>
           <span class="date">{{ post.created_at|date:"Y-m-d" }}</span>


### PR DESCRIPTION
## 요약
- 글로벌 CSS에 뱃지 스타일을 추가했습니다.
- 게시글 목록과 상세 페이지에서 작성자와 댓글 작성자의 등급 뱃지가 노출되도록 수정했습니다.

## 테스트
- `python manage.py check` 실행

------
https://chatgpt.com/codex/tasks/task_e_6846502e365c8330a8f183afebcb6a33