### PR TITLE
Add user ranking to main page

### DIFF
--- a/main/static/main/main.css
+++ b/main/static/main/main.css
@@ -263,3 +263,30 @@ section {
   font-size: 11px;
   margin-top: 2px;
 }
+
+/* 랭킹 섹션 스타일 */
+.rank-section {
+  max-width: 600px;
+  margin: 40px auto;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.rank-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.rank-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 16px;
+  border-bottom: 1px solid #eee;
+}
+
+.rank-item:last-child {
+  border-bottom: none;
+}

--- a/main/templates/main/main.html
+++ b/main/templates/main/main.html
@@ -114,6 +114,24 @@
         {% endfor %}
       </div>
     </section>
+
+    <section class="rank-section">
+      <h2 class="section-title">사용자 EXP 랭킹</h2>
+      <ul class="rank-list">
+        {% for user in top_users %}
+        <li class="rank-item">
+          <span>
+            {% if forloop.counter == 1 %}🥇{% elif forloop.counter == 2 %}🥈{% elif forloop.counter == 3 %}🥉{% else %}{{ forloop.counter }}.{% endif %}
+            {{ user.nickname }}
+            <span class="rank-badge rank-{{ user.rank_level }}">{{ user.rank }}</span>
+          </span>
+          <span>{{ user.exp }} EXP</span>
+        </li>
+        {% empty %}
+        <li>랭킹 정보가 없습니다.</li>
+        {% endfor %}
+      </ul>
+    </section>
     {% include 'main/footer.html' %}
     <div id="popupMessage" class="popup-message" style="display: none"></div>
     <!-- 팝업 메시지 -->

--- a/main/views.py
+++ b/main/views.py
@@ -1,14 +1,19 @@
 from django.shortcuts import render
 from posts.models import Post
+from account.models import CustomUser
 
 def home(request):
     # 모집중인 재능기부 최근 4개
     donation_posts = Post.objects.filter(post_type='donation').order_by('-created_at')[:4]
-    
+
     # 따뜻한 이야기 최근 4개
     story_posts = Post.objects.filter(post_type='story').order_by('-created_at')[:4]
-    
+
+    # EXP 기준 상위 사용자 10명
+    top_users = CustomUser.objects.order_by('-exp')[:10]
+
     return render(request, 'main/main.html', {
         'donation_posts': donation_posts,
         'story_posts': story_posts,
+        'top_users': top_users,
     })


### PR DESCRIPTION
## Summary
- 메인 페이지 하단에 사용자 EXP 랭킹 섹션을 추가했습니다.
- 랭킹에 따라 금/은/동 메달과 순위를 표시하도록 했습니다.
- 랭킹 보기를 위한 스타일을 main.css에 추가했습니다.

## Testing
- `python manage.py test` 실행 시 Django 모듈이 없어서 실패했습니다.

------
https://chatgpt.com/codex/tasks/task_e_68466610dcac8330bba089b07f6eee3e